### PR TITLE
Adding CLAUDE.md file to import cursor rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Uiscias
+
+Shared rules live in `.cursor/rules/` and are imported below so Cursor and
+Claude Code follow the same source of truth. Edit the `.mdc` files, not this
+list.
+
+@.cursor/rules/environment.mdc
+@.cursor/rules/coding-conventions.mdc
+@.cursor/rules/typescript.mdc


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` that `@`-imports the existing `.cursor/rules/*.mdc` files (`environment`, `coding-conventions`, `typescript`) so Claude Code picks up the same guidance Cursor already uses.
- `.cursor/rules/` stays the single source of truth — editing an `.mdc` file updates both tools, nothing to keep in sync manually.

## Notes
- All three rules are `alwaysApply: true`, so a straight import gives full parity today.
- Caveat: Claude Code imports are all-or-nothing (no glob scoping), so if a rule is later scoped with `globs:` for specific files, Claude will still apply it globally.