### PR TITLE
Update pre-commit hook to run formatters first and enhance config generation checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,10 +5,18 @@ if ! command -v node >/dev/null 2>&1; then
   fi
 fi
 
+# Formatters run FIRST: generate-configs captures README.md into config.json, so
+# prettier/markdownlint must normalize the README before it is read, or the
+# embedded copy drifts from the file and the CI drift check fails.
+npx lint-staged || exit 1
+
 # For staged mod changes: validate config.yaml + regenerate config.json, then
 # pack the .it (bump-by-hash). Both stage their outputs so they land in this
 # commit. Scoped to changed mods so the per-commit cost stays small.
 npx tsx scripts/src/index.ts generate-configs --changed --staged --stage || exit 1
 npx tsx scripts/src/index.ts pack --changed --staged --stage || exit 1
 
-npx lint-staged
+# Guard: generated output must still be byte-stable once every other step has
+# run. Passes trivially in the order above; it exists so a future reordering (or
+# a new step that rewrites files) fails here instead of in CI.
+npx tsx scripts/src/index.ts generate-configs --changed --staged --check || exit 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -508,16 +508,25 @@ appears on bulk changes, which can instead use the explicit `npm run`
 all-mods commands.
 
 - **`pre-commit`**: for staged/changed mods, in order —
-  1. validate `config.yaml` against the schema (fail the commit on errors),
-  2. `generate-configs` (refresh `config.json` + `sourceHash`),
-  3. `pack` the changed mods (repack only when `sourceHash` differs from
+  1. run prettier + markdownlint on the staged files (via `lint-staged`; see
+     [Markdown linting](#markdown-linting-readme--docs)),
+  2. validate `config.yaml` against the schema (fail the commit on errors),
+  3. `generate-configs` (refresh `config.json` + `sourceHash`),
+  4. `pack` the changed mods (repack only when `sourceHash` differs from
      `build.lock.json`), writing the new `.it` + `build.lock.json`,
-  4. `git add` the regenerated `config.json`, `.it`, and `build.lock.json` so
+  5. `git add` the regenerated `config.json`, `.it`, and `build.lock.json` so
      they land in the same commit,
-  5. run prettier + markdownlint (via `lint-staged`; see
-     [Markdown linting](#markdown-linting-readme--docs)).
+  6. re-run `generate-configs --check` as a closing guard.
      Each maintainer is on Windows with `mabi-pack2.exe` available locally (see the
      environment rules), so packing in the hook is viable.
+- **The formatters must run first.** `generate-configs` captures `README.md` into
+  `config.json.readme`, so if prettier reformats the README afterwards the
+  committed file and its embedded copy disagree forever and CI's `npm run check`
+  fails. This bit us once: a lone trailing space mid-README (which `.trim()` does
+  not catch) shipped inside `config.json` while the README itself was cleaned.
+  `readReadme` now also normalizes the text with prettier before embedding it, so
+  the invariant holds even for a `--no-verify` commit; step 6 catches any future
+  reordering locally instead of in CI.
 - The same operations are also available as explicit, all-mods npm commands
   (`npm run generate-configs`, `npm run pack`) for bulk rebuilds or recovery.
 
@@ -536,11 +545,11 @@ enforced without fighting Prettier on formatting.
 
 **Where it runs:**
 
-| Trigger                      | What happens                                                                        |
-| ---------------------------- | ----------------------------------------------------------------------------------- |
-| `pre-commit` (`lint-staged`) | On staged scoped files: Prettier `--write`, then `markdownlint-cli2 --fix`          |
-| CI `format` job              | `npm run format:check` (Prettier) then `npm run lint:md` (markdownlint, no `--fix`) |
-| Local                        | `npm run lint:md`; `npm run format` for Prettier                                    |
+| Trigger                      | What happens                                                                                             |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `pre-commit` (`lint-staged`) | On staged scoped files, **before** config generation: Prettier `--write`, then `markdownlint-cli2 --fix` |
+| CI `format` job              | `npm run format:check` (Prettier) then `npm run lint:md` (markdownlint, no `--fix`)                      |
+| Local                        | `npm run lint:md`; `npm run format` for Prettier                                                         |
 
 `new-mod` scaffolds a README that already matches the expected three-section
 shape (`## What it does` / `### How it's made`). Image markdown is not used in

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@ schemas, and conventions referenced below.
 | --------------------------------- | --------------------------------------------------------------------------------------------- |
 | `.it` storage                     | Commit **latest only** per mod as **plain git files** (no LFS); older versions in releases    |
 | `manifestCatalog.json` generation | At **release time** in CI, aggregated from committed `config.json`                            |
-| Commit hook scope                 | `pre-commit` = yaml → generate-configs → pack (changed) → prettier + markdownlint             |
+| Commit hook scope                 | `pre-commit` = prettier + markdownlint → yaml → generate-configs → pack (changed) → re-check  |
 | Build script language             | **Node/TypeScript**                                                                           |
 | CLI parsing & color               | **commander** (subcommands + generated help) + **picocolors** (TTY-aware color)               |
 | Mod location                      | All mods live under **`mods/`**; single source of truth `MODS_DIR`/`getModsRoot` in `repo.ts` |
@@ -104,11 +104,12 @@ repack verified; idempotent).
 
 ### Phase 4 — Hooks & npm scripts ✅
 
-- [x] `pre-commit` (for changed mods): validate yaml → `generate-configs` →
-      `pack` → `git add` regenerated `config.json` + `.it` + `build.lock.json` →
-      prettier + markdownlint (`lint-staged`, scoped to mod READMEs, `docs/`,
-      and the root `README.md`); fails on invalid yaml. (`--stage` does the
-      `git add`.)
+- [x] `pre-commit` (for changed mods): prettier + markdownlint (`lint-staged`,
+      scoped to mod READMEs, `docs/`, and the root `README.md`) → validate yaml →
+      `generate-configs` → `pack` → `git add` regenerated `config.json` + `.it` +
+      `build.lock.json` → `generate-configs --check` as a closing guard; fails on
+      invalid yaml. (`--stage` does the `git add`.) The formatters run **first**
+      because `generate-configs` captures `README.md` into `config.json`.
 - [x] Add npm scripts: `generate-configs`, `pack`, `build-manifest` (+ `check`,
       `typecheck`, `mods`, `changed`, `new-mod`, `new-mod-variant`).
 - [x] Add `.gitattributes` (LF text, binary `.it`/assets) for cross-platform

--- a/scripts/src/commands/check.ts
+++ b/scripts/src/commands/check.ts
@@ -3,7 +3,7 @@ import { fse } from '../lib/io';
 import { getRepoRoot } from '../lib/repo';
 import { discoverMods, packTargets } from '../lib/mods';
 import { computeDataHash } from '../lib/hash';
-import { readConfigJson, readBuildLock } from '../lib/config';
+import { readConfigJson, readBuildLock, ConfigError } from '../lib/config';
 import { itBelongsToId } from '../lib/itFile';
 import { readVersionLedgerStrict, floorFor } from '../lib/versionLedger';
 import { ok, err, glyph, Tally } from '../lib/term';
@@ -51,8 +51,13 @@ export const runCheck = async (): Promise<void> => {
     try {
       sourceHash = readConfigJson(mod).sourceHash;
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      tally.addError(`${mod.relDir}: unreadable config.json (${message})`);
+      // ConfigError already names the mod and the problem; anything else is a
+      // read/JSON-syntax failure that still needs the path for context.
+      tally.addError(
+        e instanceof ConfigError
+          ? e.message
+          : `${mod.relDir}: unreadable config.json (${String(e)})`,
+      );
       continue;
     }
     if (sourceHash !== hash) {

--- a/scripts/src/commands/generateConfigs.ts
+++ b/scripts/src/commands/generateConfigs.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
 import { fse, readText, formatJson, writeJsonFile } from '../lib/io';
 import { getRepoRoot } from '../lib/repo';
-import { discoverMods } from '../lib/mods';
+import { discoverMods, type Mod } from '../lib/mods';
 import { resolveTargetMods, type ScopeOptions } from '../lib/scope';
 import { buildConfigJson, ConfigError } from '../lib/config';
+import { describeConfigDrift } from '../lib/configDrift';
 import { gitAdd } from '../lib/git';
 import { ok, warn, dim, glyph, Tally } from '../lib/term';
 
@@ -11,6 +12,21 @@ export interface GenerateConfigsOptions extends ScopeOptions {
   /** Verify mode: fail if any config.json would change; do not write. */
   check?: boolean;
 }
+
+type StaleMod = { readonly mod: Mod; readonly reasons: readonly string[] };
+
+/**
+ * Report a stale mod with the reasons indented beneath it, then the command that
+ * fixes it. A reason may span several lines (a before/after snippet), so every
+ * line is indented rather than just the first.
+ */
+const printStale = ({ mod, reasons }: StaleMod): void => {
+  console.log(`  ${glyph.bad} ${warn('stale')}: ${mod.relDir}`);
+  for (const reason of reasons) {
+    for (const line of reason.split('\n')) console.log(`      ${dim(line)}`);
+  }
+  console.log(`      ${dim(`Fix: npm run generate-configs -- --mods ${mod.id}`)}`);
+};
 
 /**
  * Regenerate (or, with --check, verify) config.json for the target mods from
@@ -23,14 +39,14 @@ export const runGenerateConfigs = async (opts: GenerateConfigsOptions): Promise<
   const targets = resolveTargetMods(repoRoot, mods, opts);
 
   const tally = new Tally();
-  const stale: string[] = [];
+  const stale: StaleMod[] = [];
   const writtenPaths: string[] = [];
 
   for (const mod of targets) {
     const jsonPath = path.join(mod.dir, 'config.json');
     let desired: string;
     try {
-      desired = await formatJson(buildConfigJson(mod), jsonPath);
+      desired = await formatJson(await buildConfigJson(mod), jsonPath);
     } catch (e) {
       tally.addError(e instanceof ConfigError ? e.message : `${mod.relDir}: ${String(e)}`);
       continue;
@@ -44,7 +60,7 @@ export const runGenerateConfigs = async (opts: GenerateConfigsOptions): Promise<
     }
 
     if (opts.check) {
-      stale.push(mod.relDir);
+      stale.push({ mod, reasons: describeConfigDrift(current, desired) });
     } else {
       await writeJsonFile(jsonPath, JSON.parse(desired));
       writtenPaths.push(jsonPath);
@@ -61,7 +77,7 @@ export const runGenerateConfigs = async (opts: GenerateConfigsOptions): Promise<
     console.log(
       `Checked ${targets.length} mod(s): ${dim(`${tally.get('unchanged')} up to date`)}, ${staleText}.`,
     );
-    for (const s of stale) console.log(`  ${glyph.bad} ${warn('stale')}: ${s}`);
+    for (const s of stale) printStale(s);
   } else {
     console.log(
       `Generated configs for ${targets.length} mod(s): ${ok(`${tally.get('written')} written`)}, ${dim(`${tally.get('unchanged')} unchanged`)}.`,

--- a/scripts/src/lib/config.test.ts
+++ b/scripts/src/lib/config.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { ConfigError, buildConfigJson, loadConfigYaml, readBuildLock } from './config';
+import {
+  ConfigError,
+  buildConfigJson,
+  loadConfigYaml,
+  readBuildLock,
+  readConfigJson,
+} from './config';
 import { CONFIG_JSON_KEY_ORDER } from '../schema';
 import type { Mod } from './mods';
 
@@ -145,6 +151,42 @@ describe('config', () => {
         'utf8',
       );
       expect((await buildConfigJson(mod)).findiasTags).toEqual(['Combat', 'QoL', 'UI']);
+    });
+  });
+
+  describe('readConfigJson', () => {
+    it('reads and validates a committed config.json', async () => {
+      const mod = await makeMod();
+      const generated = await buildConfigJson(mod);
+      await fs.writeFile(join(mod.dir, 'config.json'), JSON.stringify(generated), 'utf8');
+      expect(readConfigJson(mod)).toEqual(generated);
+    });
+
+    // A raw ZodError stringifies to a multi-line dump of issue objects, which is
+    // unreadable once a caller embeds it in a one-line error.
+    it('throws a ConfigError with the issues formatted on one line', async () => {
+      const mod = await makeMod();
+      const generated = await buildConfigJson(mod);
+      const invalid = { ...generated, sourceHash: 'not-a-hash', surprise: 1 };
+      await fs.writeFile(join(mod.dir, 'config.json'), JSON.stringify(invalid), 'utf8');
+
+      expect(() => readConfigJson(mod)).toThrow(ConfigError);
+      try {
+        readConfigJson(mod);
+        expect.unreachable('readConfigJson should have thrown');
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        expect(message).not.toContain('\n');
+        expect(message).toContain('mods/Zoom: invalid config.json —');
+        expect(message).toContain('sourceHash:');
+        expect(message).toContain('Unrecognized key');
+      }
+    });
+
+    it('throws a non-ConfigError for a syntactically broken config.json', async () => {
+      const mod = await makeMod();
+      await fs.writeFile(join(mod.dir, 'config.json'), '{ "modId": ', 'utf8');
+      expect(() => readConfigJson(mod)).toThrow(SyntaxError);
     });
   });
 

--- a/scripts/src/lib/config.test.ts
+++ b/scripts/src/lib/config.test.ts
@@ -70,7 +70,7 @@ describe('config', () => {
   describe('buildConfigJson', () => {
     it('produces a config in canonical key order with scanned files + hash', async () => {
       const mod = await makeMod();
-      const cfg = buildConfigJson(mod);
+      const cfg = await buildConfigJson(mod);
 
       // No README / images / credits / notes, so those keys are omitted (lean mods).
       expect(Object.keys(cfg)).toEqual(BASE_KEYS);
@@ -86,7 +86,7 @@ describe('config', () => {
 
     it('flags variants via isVariant', async () => {
       const mod = await makeMod('variant');
-      expect(buildConfigJson(mod).isVariant).toBe(true);
+      expect((await buildConfigJson(mod)).isVariant).toBe(true);
     });
 
     it('includes optional credits + notes when the yaml sets them', async () => {
@@ -96,7 +96,7 @@ describe('config', () => {
         `${YAML_MIN}modAdditionalCredits: Thanks Bri\nrecentUpdateNotes: Fixed the thing\n`,
         'utf8',
       );
-      const cfg = buildConfigJson(mod);
+      const cfg = await buildConfigJson(mod);
       expect(cfg.modAdditionalCredits).toBe('Thanks Bri');
       expect(cfg.recentUpdateNotes).toBe('Fixed the thing');
       // Present optional fields still land in canonical order (no README / images).
@@ -104,7 +104,7 @@ describe('config', () => {
       expect(Object.keys(cfg)).toEqual(keysNoDocs);
     });
 
-    it('reads README.md verbatim and scans images/ in canonical key order', async () => {
+    it('reads README.md and scans images/ in canonical key order', async () => {
       const mod = await makeMod();
       await fs.writeFile(join(mod.dir, 'README.md'), '# Zoom\n\nHello.\n', 'utf8');
       const imagesDir = join(mod.dir, 'images');
@@ -112,7 +112,7 @@ describe('config', () => {
       await fs.writeFile(join(imagesDir, 'b.png'), 'x');
       await fs.writeFile(join(imagesDir, 'a.gif'), 'x');
 
-      const cfg = buildConfigJson(mod);
+      const cfg = await buildConfigJson(mod);
       // YAML_MIN sets no credits/notes, so those keys are absent; readme/images present.
       const keysWithDocs = CONFIG_JSON_KEY_ORDER.filter(
         (k) => k !== 'modAdditionalCredits' && k !== 'recentUpdateNotes',
@@ -125,7 +125,16 @@ describe('config', () => {
     it('omits readme for an empty README.md', async () => {
       const mod = await makeMod();
       await fs.writeFile(join(mod.dir, 'README.md'), '   \n', 'utf8');
-      expect(buildConfigJson(mod).readme).toBeUndefined();
+      expect((await buildConfigJson(mod)).readme).toBeUndefined();
+    });
+
+    // The readme is embedded into config.json, so capturing it before Prettier
+    // has normalized it leaves the two permanently out of sync (a trailing space
+    // mid-document survives `.trim()` and fails the CI drift check).
+    it('normalizes the README with Prettier before embedding it', async () => {
+      const mod = await makeMod();
+      await fs.writeFile(join(mod.dir, 'README.md'), '# Zoom\n\nTrailing space here. \n', 'utf8');
+      expect((await buildConfigJson(mod)).readme).toBe('# Zoom\n\nTrailing space here.');
     });
 
     it('sorts findiasTags alphabetically regardless of config.yaml order', async () => {
@@ -135,7 +144,7 @@ describe('config', () => {
         `${YAML_MIN}findiasTags:\n  - UI\n  - Combat\n  - QoL\n`,
         'utf8',
       );
-      expect(buildConfigJson(mod).findiasTags).toEqual(['Combat', 'QoL', 'UI']);
+      expect((await buildConfigJson(mod)).findiasTags).toEqual(['Combat', 'QoL', 'UI']);
     });
   });
 

--- a/scripts/src/lib/config.ts
+++ b/scripts/src/lib/config.ts
@@ -93,9 +93,18 @@ export const buildConfigJson = async (mod: Mod): Promise<ConfigJson> => {
   return configJsonSchema.parse(orderKeys(configJsonSchema.parse(config), CONFIG_JSON_KEY_ORDER));
 };
 
-/** Read + validate a mod's committed config.json. */
+/**
+ * Read + validate a mod's committed config.json. Schema failures surface as a
+ * `ConfigError` with the issues formatted the same way `loadConfigYaml` does —
+ * a raw ZodError stringifies to a multi-line dump of issue objects, which is
+ * unreadable when embedded in a one-line CI error.
+ */
 export const readConfigJson = (mod: Mod): ConfigJson =>
-  configJsonSchema.parse(readJsonFile(path.join(mod.dir, 'config.json')));
+  parseOrThrow(
+    configJsonSchema,
+    readJsonFile(path.join(mod.dir, 'config.json')),
+    (issues) => new ConfigError(`${mod.relDir}: invalid config.json — ${issues}`),
+  );
 
 /** Read + validate a build/build.lock.json, if present. */
 export const readBuildLock = (buildDir: string): BuildLock | undefined => {

--- a/scripts/src/lib/config.ts
+++ b/scripts/src/lib/config.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { fse, readText, readYamlFile, orderKeys, readJsonFile } from './io';
+import { fse, readText, readYamlFile, orderKeys, readJsonFile, formatText } from './io';
 import { scanUsedFiles, scanImages, computeDataHash } from './hash';
 import type { Mod } from './mods';
 import {
@@ -54,19 +54,27 @@ export const readCatalogConfig = (repoRoot: string): CatalogConfig => {
   );
 };
 
-/** Read a mod's README.md verbatim, or `undefined` when it has none. */
-const readReadme = (mod: Mod): string | undefined => {
+/**
+ * Read a mod's README.md, or `undefined` when it has none. Formatted with
+ * Prettier first: the text is embedded verbatim into config.json, so capturing
+ * it raw would drift from the file the moment the `lint-staged` Prettier pass
+ * normalizes it (e.g. dropping a stray trailing space mid-document, which
+ * `.trim()` alone does not catch).
+ */
+const readReadme = async (mod: Mod): Promise<string | undefined> => {
   const readmePath = path.join(mod.dir, 'README.md');
   if (!fse.pathExistsSync(readmePath)) return undefined;
-  const text = readText(readmePath).trim();
+  const raw = readText(readmePath);
+  if (raw.trim().length === 0) return undefined;
+  const text = (await formatText(raw, 'markdown', readmePath)).trim();
   return text.length > 0 ? text : undefined;
 };
 
 /** Build the generated config.json object for a mod (deterministic key order). */
-export const buildConfigJson = (mod: Mod): ConfigJson => {
+export const buildConfigJson = async (mod: Mod): Promise<ConfigJson> => {
   const yaml = loadConfigYaml(mod);
   const dataDir = mod.dataDir ?? path.join(mod.dir, 'data');
-  const readme = readReadme(mod);
+  const readme = await readReadme(mod);
   const images = scanImages(mod.dir);
 
   const config: ConfigJson = {

--- a/scripts/src/lib/configDrift.test.ts
+++ b/scripts/src/lib/configDrift.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { describeConfigDrift } from './configDrift';
+
+/** A config.json body, serialized the way `formatJson` would emit it. */
+const asJson = (value: Record<string, unknown>): string => `${JSON.stringify(value, null, 2)}\n`;
+
+const BASE = {
+  modId: 'Zoom',
+  modName: 'Zoom Mod',
+  updateType: 'stable',
+  usedFiles: ['data/a.xml', 'data/b.xml'],
+  sourceHash: `sha256-${'a'.repeat(64)}`,
+} satisfies Record<string, unknown>;
+
+describe('describeConfigDrift', () => {
+  it('reports a missing config.json', () => {
+    expect(describeConfigDrift(null, asJson(BASE))).toEqual(['missing config.json']);
+  });
+
+  it('reports an unparseable config.json', () => {
+    const reasons = describeConfigDrift('{ "modId": ', asJson(BASE));
+    expect(reasons).toEqual(['not valid JSON — the file was hand-edited or truncated']);
+  });
+
+  it('reports formatting-only drift when every value still matches', () => {
+    const current = `${JSON.stringify({ modName: 'Zoom Mod', modId: 'Zoom' })}\n`;
+    const desired = asJson({ modId: 'Zoom', modName: 'Zoom Mod' });
+    expect(describeConfigDrift(current, desired)).toEqual([
+      'JSON formatting differs (key order or indentation)',
+    ]);
+  });
+
+  it('reports a field the committed file is missing', () => {
+    const desired = asJson({ ...BASE, recentUpdateNotes: 'added bomb timer' });
+    expect(describeConfigDrift(asJson(BASE), desired)).toEqual([
+      'recentUpdateNotes: missing, should be "added bomb timer"',
+    ]);
+  });
+
+  it('reports a field that is no longer generated', () => {
+    const current = asJson({ ...BASE, images: ['old.png'] });
+    expect(describeConfigDrift(current, asJson(BASE))).toEqual([
+      'images: no longer generated, but committed as 1 entry',
+    ]);
+  });
+
+  it('reports added and removed array entries', () => {
+    const desired = asJson({ ...BASE, usedFiles: ['data/a.xml', 'data/c.xml'] });
+    expect(describeConfigDrift(asJson(BASE), desired)).toEqual([
+      'usedFiles: +1 missing ("data/c.xml"), -1 stale ("data/b.xml")',
+    ]);
+  });
+
+  it('reports a reordered array without listing entries', () => {
+    const desired = asJson({ ...BASE, usedFiles: ['data/b.xml', 'data/a.xml'] });
+    expect(describeConfigDrift(asJson(BASE), desired)).toEqual([
+      'usedFiles: same 2 entries, different order',
+    ]);
+  });
+
+  it('quotes short single-line strings inline', () => {
+    const desired = asJson({ ...BASE, modName: 'Zoom Mod 2' });
+    expect(describeConfigDrift(asJson(BASE), desired)).toEqual([
+      'modName: "Zoom Mod" → "Zoom Mod 2"',
+    ]);
+  });
+
+  it('summarizes a type change', () => {
+    const desired = asJson({ ...BASE, isVariant: true });
+    const current = asJson({ ...BASE, isVariant: 'yes' });
+    expect(describeConfigDrift(current, desired)).toEqual(['isVariant: "yes" → true']);
+  });
+
+  // The PR #165 regression: `generate-configs` ran before Prettier stripped a
+  // trailing space from the README, so the embedded copy kept it. The old report
+  // said only "stale: mods/BriMidirEffects", which hid a one-character cause.
+  it('pinpoints a trailing space inside the embedded readme', () => {
+    const lines = ['# Bri Midir Effects', '', '## What it does', '', 'Tornado effects replaced.'];
+    const desired = asJson({ ...BASE, readme: [...lines, 'Halo beam is now blue.'].join('\n') });
+    const current = asJson({ ...BASE, readme: [...lines, 'Halo beam is now blue. '].join('\n') });
+
+    expect(describeConfigDrift(current, desired)).toEqual([
+      [
+        'readme: line 6 differs (trailing whitespace)',
+        '  committed: Halo beam is now blue.·',
+        '  expected:  Halo beam is now blue.',
+      ].join('\n'),
+    ]);
+  });
+
+  it('makes a tab visible in a readme snippet', () => {
+    const readme = '# Zoom\n\nIndented line.';
+    const current = asJson({ ...BASE, readme: '# Zoom\n\n\tIndented line.' });
+    const desired = asJson({ ...BASE, readme });
+
+    expect(describeConfigDrift(current, desired)).toEqual([
+      [
+        'readme: line 3 differs (leading whitespace)',
+        '  committed: →Indented line.',
+        '  expected:  Indented line.',
+      ].join('\n'),
+    ]);
+  });
+
+  it('windows a long readme line around the first difference', () => {
+    const prefix = 'x'.repeat(200);
+    const current = asJson({ ...BASE, readme: `# Zoom\n\n${prefix}alpha` });
+    const desired = asJson({ ...BASE, readme: `# Zoom\n\n${prefix}omega` });
+
+    const [reason] = describeConfigDrift(current, desired);
+    expect(reason).toContain('readme: line 3 differs');
+    // The skipped prefix is elided, the divergence itself stays on screen, and
+    // the whole snippet is short enough to read in a CI log.
+    expect(reason).toContain('  committed: …');
+    expect(reason).toContain('alpha');
+    expect(reason).toContain('omega');
+    for (const line of reason.split('\n')) expect(line.length).toBeLessThan(110);
+  });
+
+  it('elides both ends when the difference is mid-line', () => {
+    const pad = 'x'.repeat(200);
+    const current = asJson({ ...BASE, readme: `# Zoom\n\n${pad}alpha${pad}` });
+    const desired = asJson({ ...BASE, readme: `# Zoom\n\n${pad}omega${pad}` });
+
+    const [reason] = describeConfigDrift(current, desired);
+    expect(reason).toContain('  committed: …');
+    expect(reason).toMatch(/alpha.*…$/m);
+  });
+
+  it('reports a line count difference in the readme', () => {
+    const current = asJson({ ...BASE, readme: '# Zoom\n\nOne.' });
+    const desired = asJson({ ...BASE, readme: '# Zoom\n\nOne.\nTwo.\nThree.' });
+    expect(describeConfigDrift(current, desired)).toEqual(['readme: 2 lines missing at line 4']);
+  });
+
+  it('caps the report and counts the remaining fields', () => {
+    const current = asJson({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7 });
+    const desired = asJson({ a: 10, b: 20, c: 30, d: 40, e: 50, f: 60, g: 70 });
+    const reasons = describeConfigDrift(current, desired);
+
+    expect(reasons).toHaveLength(6);
+    expect(reasons[0]).toBe('a: 1 → 10');
+    expect(reasons[5]).toBe('… and 2 more field(s)');
+  });
+});

--- a/scripts/src/lib/configDrift.ts
+++ b/scripts/src/lib/configDrift.ts
@@ -1,0 +1,237 @@
+import { z } from 'zod';
+
+/**
+ * Explain *why* a committed config.json differs from the freshly generated one.
+ *
+ * `generate-configs --check` only knows the two are not byte-identical, which
+ * makes a one-character difference (a stray trailing space inside the embedded
+ * README, say) invisible in CI output. These reasons name the field that moved
+ * and, for prose fields, point at the exact line with whitespace made visible.
+ */
+
+/** Fields reported before the rest are summarized as a count. */
+const MAX_FIELDS = 5;
+/** Array entries listed per +/- group before the rest are summarized. */
+const MAX_ARRAY_ENTRIES = 3;
+/** Characters of a line kept on either side of the first differing character. */
+const WINDOW_RADIUS = 45;
+/** Single-line strings up to this length are shown whole instead of windowed. */
+const INLINE_STRING_LIMIT = 80;
+
+const jsonObjectSchema = z.record(z.string(), z.unknown());
+
+/**
+ * Human-readable reasons the committed config.json is stale, most significant
+ * first. Entries may span multiple lines; callers should indent every line.
+ * `currentText` is `null` when the file does not exist yet.
+ */
+export const describeConfigDrift = (
+  currentText: string | null,
+  desiredText: string,
+): readonly string[] => {
+  if (currentText === null) return ['missing config.json'];
+
+  const current = parseJsonObject(currentText);
+  if (!current) return ['not valid JSON — the file was hand-edited or truncated'];
+
+  const desired = parseJsonObject(desiredText);
+  if (!desired) return ['could not parse the regenerated config.json'];
+
+  const fields = describeFieldDrift(current, desired);
+  // Every value matches, so the bytes differ only in key order or indentation.
+  if (fields.length === 0) return ['JSON formatting differs (key order or indentation)'];
+
+  if (fields.length <= MAX_FIELDS) return fields;
+  const rest = fields.length - MAX_FIELDS;
+  return [...fields.slice(0, MAX_FIELDS), `… and ${rest} more field(s)`];
+};
+
+const parseJsonObject = (text: string): Record<string, unknown> | undefined => {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  const parsed = jsonObjectSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+};
+
+/**
+ * One reason per field that differs. Generated keys come first so the report
+ * follows CONFIG_JSON_KEY_ORDER, with any leftover committed-only keys after.
+ */
+const describeFieldDrift = (
+  current: Record<string, unknown>,
+  desired: Record<string, unknown>,
+): readonly string[] => {
+  const fields = [...new Set([...Object.keys(desired), ...Object.keys(current)])];
+  const reasons: string[] = [];
+
+  for (const field of fields) {
+    if (!(field in current)) {
+      reasons.push(`${field}: missing, should be ${summarize(desired[field])}`);
+      continue;
+    }
+    if (!(field in desired)) {
+      reasons.push(`${field}: no longer generated, but committed as ${summarize(current[field])}`);
+      continue;
+    }
+    const detail = describeValueDrift(current[field], desired[field]);
+    if (detail) reasons.push(`${field}: ${detail}`);
+  }
+
+  return reasons;
+};
+
+const describeValueDrift = (current: unknown, desired: unknown): string | undefined => {
+  if (JSON.stringify(current) === JSON.stringify(desired)) return undefined;
+
+  if (typeof current === 'string' && typeof desired === 'string') {
+    return describeStringDrift(current, desired);
+  }
+  if (isStringArray(current) && isStringArray(desired)) {
+    return describeStringArrayDrift(current, desired);
+  }
+  return `${summarize(current)} → ${summarize(desired)}`;
+};
+
+/**
+ * Locate the difference in a text field. Short single-line values are quoted
+ * inline; anything longer (notably `readme`) reports the line number plus an
+ * aligned before/after window around the first differing character.
+ */
+const describeStringDrift = (current: string, desired: string): string => {
+  const currentLines = current.split('\n');
+  const desiredLines = desired.split('\n');
+
+  const isSingleLine = currentLines.length === 1 && desiredLines.length === 1;
+  const isShort = current.length <= INLINE_STRING_LIMIT && desired.length <= INLINE_STRING_LIMIT;
+  if (isSingleLine && isShort) {
+    return `${JSON.stringify(current)} → ${JSON.stringify(desired)}`;
+  }
+
+  const lineIndex = firstDifferenceIndex(currentLines, desiredLines);
+  const currentLine = currentLines[lineIndex];
+  const desiredLine = desiredLines[lineIndex];
+
+  if (currentLine === undefined) {
+    return `${countLines(desiredLines.length - currentLines.length)} missing at line ${lineIndex + 1}`;
+  }
+  if (desiredLine === undefined) {
+    return `${countLines(currentLines.length - desiredLines.length)} extra at line ${lineIndex + 1}`;
+  }
+
+  const cause = whitespaceCause(currentLine, desiredLine);
+  const where = isSingleLine ? 'differs' : `line ${lineIndex + 1} differs`;
+
+  // Whitespace glyphs are 1:1 substitutions, so the window still lines up.
+  const shownCurrent = visibleWhitespace(currentLine);
+  const shownDesired = visibleWhitespace(desiredLine);
+  const window = windowAround(firstDifferenceIndex(currentLine, desiredLine), [
+    shownCurrent,
+    shownDesired,
+  ]);
+
+  return [
+    cause ? `${where} (${cause})` : where,
+    `  committed: ${snippet(shownCurrent, window)}`,
+    `  expected:  ${snippet(shownDesired, window)}`,
+  ].join('\n');
+};
+
+const describeStringArrayDrift = (
+  current: readonly string[],
+  desired: readonly string[],
+): string => {
+  const added = desired.filter((entry) => !current.includes(entry));
+  const removed = current.filter((entry) => !desired.includes(entry));
+  if (added.length === 0 && removed.length === 0) {
+    return `same ${desired.length} entries, different order`;
+  }
+
+  const parts: string[] = [];
+  if (added.length > 0) parts.push(`+${added.length} missing (${previewEntries(added)})`);
+  if (removed.length > 0) parts.push(`-${removed.length} stale (${previewEntries(removed)})`);
+  return parts.join(', ');
+};
+
+const previewEntries = (entries: readonly string[]): string => {
+  const shown = entries
+    .slice(0, MAX_ARRAY_ENTRIES)
+    .map((entry) => JSON.stringify(entry))
+    .join(', ');
+  const rest = entries.length - MAX_ARRAY_ENTRIES;
+  return rest > 0 ? `${shown}, … and ${rest} more` : shown;
+};
+
+const isStringArray = (value: unknown): value is readonly string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+
+const summarize = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value.length > INLINE_STRING_LIMIT
+      ? `${JSON.stringify(value.slice(0, INLINE_STRING_LIMIT))}…`
+      : JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `${countEntries(value.length)}`;
+  if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+  if (value === null) return 'null';
+  if (value === undefined) return 'absent';
+  return JSON.stringify(value);
+};
+
+const countLines = (n: number): string => `${n} line${n === 1 ? '' : 's'}`;
+const countEntries = (n: number): string => `${n} entr${n === 1 ? 'y' : 'ies'}`;
+
+/**
+ * Index of the first element that differs. Reads past the end of the shorter
+ * input as `undefined`, so a pure length difference reports the first extra
+ * index rather than "equal".
+ */
+const firstDifferenceIndex = (
+  current: string | readonly string[],
+  desired: string | readonly string[],
+): number => {
+  const max = Math.max(current.length, desired.length);
+  for (let i = 0; i < max; i++) {
+    if (current[i] !== desired[i]) return i;
+  }
+  return max;
+};
+
+/** Why two lines differ, when the only difference is whitespace. */
+const whitespaceCause = (current: string, desired: string): string | undefined => {
+  if (current.trimEnd() === desired.trimEnd()) return 'trailing whitespace';
+  if (current.trimStart() === desired.trimStart()) return 'leading whitespace';
+  const collapse = (line: string): string => line.replace(/\s+/g, ' ').trim();
+  if (collapse(current) === collapse(desired)) return 'whitespace';
+  return undefined;
+};
+
+/**
+ * Render invisible characters that would otherwise make a diff unreadable:
+ * trailing spaces, tabs, and stray carriage returns. Each substitution is a
+ * single character so column positions are preserved.
+ */
+const visibleWhitespace = (line: string): string =>
+  line
+    .replace(/\r/g, '␍')
+    .replace(/\t/g, '→')
+    .replace(/ +$/, (run) => '·'.repeat(run.length));
+
+type Window = { readonly start: number; readonly end: number };
+
+/** A slice window shared by both snippets, so they align when printed. */
+const windowAround = (column: number, lines: readonly string[]): Window => {
+  const longest = Math.max(...lines.map((line) => line.length));
+  if (longest <= WINDOW_RADIUS * 2) return { start: 0, end: longest };
+  const start = Math.max(0, column - WINDOW_RADIUS);
+  return { start, end: start + WINDOW_RADIUS * 2 };
+};
+
+const snippet = (line: string, window: Window): string => {
+  const head = window.start > 0 ? '…' : '';
+  const tail = window.end < line.length ? '…' : '';
+  return `${head}${line.slice(window.start, window.end)}${tail}`;
+};

--- a/scripts/src/schema/configJson.ts
+++ b/scripts/src/schema/configJson.ts
@@ -25,7 +25,7 @@ export const configJsonSchema = z
     hasVariants: z.boolean(),
     usedFiles: z.array(z.string()),
     sourceHash: sourceHashSchema,
-    // Optional docs: the mod's README.md text (verbatim) and the image file
+    // Optional docs: the mod's README.md text (Prettier-normalized) and the image file
     // names scanned from its images/ folder. Both are omitted when absent, so a
     // mod without docs regenerates a byte-identical config.json.
     readme: z.string().min(1).optional(),


### PR DESCRIPTION
## Why

`generate-configs` embeds a mod's `README.md` into `config.json.readme`, but the `pre-commit` hook ran it **before** `lint-staged`. So Prettier reformatted the README *after* its text had already been captured, and the two copies disagreed permanently — CI's `npm run check` then failed on a drift the commit itself had created.

That is what happened on #165: a single trailing space mid-README (which `.trim()` does not catch) shipped inside `config.json` while the README on disk was cleaned. The `--check` output said only `stale: mods/BriMidirEffects`, which gave no way to see that the cause was one character.

## What changed

**1. Formatters run first in `.husky/pre-commit`**

`npx lint-staged` moves to the top, ahead of `generate-configs` and `pack`, so the README is normalized before it is read. A closing `generate-configs --changed --staged --check` is added at the end as a guard: it passes trivially in this order, and exists so a future reordering (or a new step that rewrites files) fails locally instead of in CI.

**2. `readReadme` normalizes with Prettier before embedding**

`readReadme` is now async and runs the README through `formatText(..., 'markdown')` before trimming. This keeps the invariant even when the hook is bypassed with `--no-verify` or when configs are regenerated outside the hook. `buildConfigJson` is async as a consequence; `generateConfigs` and the tests are updated to await it.

**3. New `scripts/src/lib/configDrift.ts` — `--check` explains itself**

`describeConfigDrift(currentText, desiredText)` turns "these bytes differ" into a readable reason per field, and `generate-configs --check` prints those reasons indented under each stale mod, followed by the exact `npm run generate-configs -- --mods <id>` that fixes it. It handles:

- missing / unparseable `config.json`, and value-identical files (key order or indentation only)
- fields added, dropped, or changed — with type changes summarized
- string arrays: `+n missing` / `-n stale` with entries previewed, or "same n entries, different order"
- prose fields (`readme`): the line number, the whitespace cause (leading / trailing / internal), and an aligned before/after snippet with tabs, `\r`, and trailing spaces rendered as visible glyphs, windowed around the first differing column so long lines stay readable in a CI log

Output is capped at 5 fields (`… and n more field(s)`) so a badly stale config does not flood the log.

For the #165 case it now reports:

```
readme: line 6 differs (trailing whitespace)
  committed: Halo beam is now blue.·
  expected:  Halo beam is now blue.
```

## Tests

`scripts/src/lib/configDrift.test.ts` is new (14 cases, one per drift shape above, including the #165 regression and the long-line windowing). `config.test.ts` gains a case asserting the README is Prettier-normalized before embedding, and its existing `buildConfigJson` cases are updated for the async signature.

## Docs

`docs/architecture.md` and `docs/roadmap.md` are updated to the new hook order, with a note recording *why* the formatters must run first. The `configJson` schema comment no longer describes `readme` as verbatim.
