### PR TITLE
Implement prerelease label propagation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  PRERELEASE_LABEL: prerelease
+
 jobs:
   # Conventional Commits drive versioning: feat → minor, fix → patch. Each push
   # to main opens/updates a release PR; merging that PR cuts the GitHub release.
@@ -39,6 +42,28 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The release PR auto-merges as soon as CI is green, leaving no window for
+      # a human to label it `prerelease`. So intent is captured on the feature
+      # PR that cut the release instead, and forwarded here onto the release PR
+      # before auto-merge is armed (ordering matters). Reuses the same "PR
+      # behind this commit" lookup as the final prerelease job. The App token
+      # is used because it has Issues write, needed for label edits.
+      - name: Propagate prerelease label to the release PR
+        if: ${{ steps.rp.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_PR: ${{ steps.rp.outputs.pr }}
+        run: |
+          labels=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[].labels[].name')
+          if echo "$labels" | grep -qx "$PRERELEASE_LABEL"; then
+            pr_number=$(echo "$RELEASE_PR" | jq -r '.number')
+            echo "Merged PR was labeled '$PRERELEASE_LABEL' -> labeling release PR #$pr_number"
+            gh pr edit "$pr_number" --add-label "$PRERELEASE_LABEL" --repo "${{ github.repository }}"
+          else
+            echo "Merged PR was not labeled '$PRERELEASE_LABEL' -> nothing to propagate"
+          fi
 
       # If release-please left an open release PR, turn on GitHub native
       # auto-merge. Branch protection on main requires the CI checks (format,
@@ -106,7 +131,10 @@ jobs:
   # touching the upload. Uses --repo, so gh needs no checkout/git context.
   # GITHUB_TOKEN already has contents + PR write from the top-level permissions
   # block, and github.sha is the release PR's merge commit, which resolves back
-  # to that PR and its labels.
+  # to that PR and its labels. The label normally arrives here via the
+  # propagation step above (copied from the feature PR that cut the release),
+  # but editing the release PR's labels directly still overrides — this job
+  # only ever looks at what's on the release PR at merge time.
   prerelease:
     needs: [release-please, assets]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
@@ -118,9 +146,9 @@ jobs:
         run: |
           labels=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
             --jq '.[].labels[].name')
-          if echo "$labels" | grep -qx 'prerelease'; then
-            echo "Found 'prerelease' label -> marking ${{ needs.release-please.outputs.tag_name }} as prerelease"
+          if echo "$labels" | grep -qx "$PRERELEASE_LABEL"; then
+            echo "Found '$PRERELEASE_LABEL' label -> marking ${{ needs.release-please.outputs.tag_name }} as prerelease"
             gh release edit "${{ needs.release-please.outputs.tag_name }}" --prerelease --repo "${{ github.repository }}"
           else
-            echo "No 'prerelease' label -> leaving ${{ needs.release-please.outputs.tag_name }} as a full release"
+            echo "No '$PRERELEASE_LABEL' label -> leaving ${{ needs.release-please.outputs.tag_name }} as a full release"
           fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -657,6 +657,37 @@ The `mabi-pack2` pack key therefore stays local and is not a CI secret. (GitHub
 `windows-latest` runners _can_ execute arbitrary `.exe`, so moving packing into
 CI later is possible — it is simply not needed by this design.)
 
+### Prereleases
+
+A release can be flagged a GitHub **prerelease** via the `prerelease` label,
+but the label is applied to the **feature** PR (the `feat`/`fix` PR that
+triggers the release), not the release PR itself:
+
+- release-please's release PR is armed for GitHub native auto-merge and lands
+  as soon as CI is green — often within minutes — leaving no realistic window
+  for a human to label it by hand.
+- Instead, a workflow step in the `release-please` job reads the labels off
+  the just-merged feature PR (the same "PR behind this commit" lookup the
+  final `prerelease` job uses) and forwards `prerelease` onto the open release
+  PR, before auto-merge is armed. From there the existing `prerelease` job
+  sees the label on the release PR at merge time and runs
+  `gh release edit ... --prerelease`, same as before.
+- The label is **sticky for the whole release cycle**: if _any_ PR that
+  contributes to an open release PR is labeled `prerelease`, the propagation
+  step re-applies the label every time that PR (or a later one) merges, so the
+  eventual release ships as a prerelease. To promote it back to a full
+  release, remove the label from the release PR directly — the final job only
+  looks at the release PR's labels at merge time, so a direct edit there still
+  wins.
+- **Only label PRs that actually cut a release** (i.e. carry a `feat`/`fix`
+  commit). Labeling a `chore`-only PR either does nothing (no release PR is
+  open, so the propagation step has nothing to label) or attaches prerelease
+  intent to whatever release PR happens to be open — the only way to hit the
+  narrow race where the label lands after that PR's auto-merge has already
+  fired.
+- Prereleases are excluded from lifetime download totals; see
+  [Download counts](#download-counts).
+
 ### Carry-forward example
 
 Release `1.0.0` ships:


### PR DESCRIPTION
## Problem

Marking a release as a GitHub prerelease required labeling release-please's auto-generated release PR with `prerelease`. But that PR auto-merges as soon as CI is green, leaving no realistic window to label it by hand.

## Fix

Move the labeling point to the feature PR (the `feat`/`fix` PR that triggers the release) and propagate the label onto the release PR before auto-merge is armed.

- `.github/workflows/release.yml`:
  - Hoists the label name into a workflow-level `env: PRERELEASE_LABEL: prerelease`, used by both steps below.
  - Adds a step in the `release-please` job that reads labels off the just-merged feature PR (`GET /repos/{repo}/commits/{sha}/pulls`) and forwards `prerelease` onto the open release PR, before auto-merge is enabled.
  - Updates the existing final `prerelease` job to reference `PRERELEASE_LABEL` and refreshes its comments; behavior is unchanged — it still checks the release PR's labels at merge time and runs `gh release edit ... --prerelease`.
- `docs/architecture.md`: adds a `### Prereleases` subsection documenting the mechanism, its sticky-per-cycle semantics, and how to override.

## For contributors

To ship a release as a prerelease, label the **feature PR**, not the release PR. The label carries forward automatically; to demote a pending release back to a full release, remove the label from the release PR directly.