### PR TITLE
Updating support game version

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -1,2 +1,2 @@
-currentGameVersion: '06.25.26'
-supportedGameVersion: '06.25.26'
+currentGameVersion: '08.13.26'
+supportedGameVersion: '08.06.26'


### PR DESCRIPTION
Trigger a breaking release for 8/13/2026 patch to enable the "disable volatile mods" button on Findias.