### PR TITLE
Add case drift check to prevent working-tree file name mismatches

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,3 +20,8 @@ npx tsx scripts/src/index.ts pack --changed --staged --stage || exit 1
 # run. Passes trivially in the order above; it exists so a future reordering (or
 # a new step that rewrites files) fails here instead of in CI.
 npx tsx scripts/src/index.ts generate-configs --changed --staged --check || exit 1
+
+# Guard: a working-tree file whose case differs from git's tracked name silently
+# drifts config.json on this case-insensitive FS and only fails on case-sensitive
+# CI. Catch it here, before the commit lands.
+npx tsx scripts/src/index.ts check-case --changed --staged || exit 1

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "pack": "tsx scripts/src/index.ts pack",
     "build-manifest": "tsx scripts/src/index.ts build-manifest",
     "check": "tsx scripts/src/index.ts check",
+    "check-case": "tsx scripts/src/index.ts check-case",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/scripts/src/commands/check.ts
+++ b/scripts/src/commands/check.ts
@@ -9,6 +9,8 @@ import { readVersionLedgerStrict, floorFor } from '../lib/versionLedger';
 import { ok, err, glyph, Tally } from '../lib/term';
 import type { VersionLedger } from '../schema';
 import { runGenerateConfigs } from './generateConfigs';
+import { collectCaseMismatches } from './checkCase';
+import { describeCaseMismatch } from '../lib/caseDrift';
 
 /**
  * CI drift check (hash-only; safe on Linux, never packs). Fails if any
@@ -95,4 +97,19 @@ export const runCheck = async (): Promise<void> => {
   console.log(`Pack drift: checked ${targets.length} mod(s), ${problemText}.`);
   for (const f of tally.errors) console.error(`  ${glyph.bad} ${f}`);
   if (tally.hasErrors) process.exitCode = 1;
+
+  // 3. Case drift: working-tree file names must match git's case-exact tracked
+  // names. Redundant on case-sensitive CI (a fresh checkout always matches git),
+  // but the single source of truth for the case guard so behavior is identical
+  // wherever `check` runs.
+  const caseResults = collectCaseMismatches(repoRoot, targets);
+  const caseProblems = caseResults.reduce((n, r) => n + r.mismatches.length, 0);
+  const caseText = caseProblems > 0 ? err(`${caseProblems} problem(s)`) : ok('0 problems');
+  console.log(`Case drift: checked ${targets.length} mod(s), ${caseText}.`);
+  for (const { mod, mismatches } of caseResults) {
+    for (const mismatch of mismatches) {
+      console.error(`  ${glyph.bad} ${mod.relDir}: ${describeCaseMismatch(mismatch)}`);
+    }
+  }
+  if (caseProblems > 0) process.exitCode = 1;
 };

--- a/scripts/src/commands/checkCase.ts
+++ b/scripts/src/commands/checkCase.ts
@@ -1,0 +1,64 @@
+import path from 'node:path';
+import { getRepoRoot } from '../lib/repo';
+import { discoverMods, packTargets, type Mod } from '../lib/mods';
+import { resolveTargetMods, type ScopeOptions } from '../lib/scope';
+import { listFilesRecursive } from '../lib/hash';
+import { gitTrackedPaths } from '../lib/git';
+import { relPosix } from '../lib/io';
+import { findCaseMismatches, describeCaseMismatch, type CaseMismatch } from '../lib/caseDrift';
+import { err, ok, glyph } from '../lib/term';
+
+export interface ModCaseMismatches {
+  readonly mod: Mod;
+  readonly mismatches: CaseMismatch[];
+}
+
+/**
+ * A mod's `data/` + `images/` files, repo-relative posix, in their real on-disk
+ * case. These are the trees that feed `usedFiles`/`sourceHash`, so a case-only
+ * divergence here is what silently drifts config.json on a case-insensitive FS.
+ */
+const scannedFilesFor = (repoRoot: string, mod: Mod): string[] => {
+  const dirs = [mod.dataDir, path.join(mod.dir, 'images')].filter(
+    (dir): dir is string => dir !== undefined,
+  );
+  return dirs.flatMap((dir) => listFilesRecursive(dir)).map((full) => relPosix(repoRoot, full));
+};
+
+/**
+ * Compare each mod's working-tree file names against git's case-exact tracked
+ * names, returning only the mods that have a case-only divergence. One
+ * `git ls-files` call for the whole run.
+ */
+export const collectCaseMismatches = (repoRoot: string, mods: Mod[]): ModCaseMismatches[] => {
+  const tracked = gitTrackedPaths(repoRoot, ['mods']);
+  const results: ModCaseMismatches[] = [];
+  for (const mod of mods) {
+    const mismatches = findCaseMismatches(tracked, scannedFilesFor(repoRoot, mod));
+    if (mismatches.length > 0) results.push({ mod, mismatches });
+  }
+  return results;
+};
+
+/**
+ * Standalone case-drift check, scoped like the other commands. Catches a
+ * working-tree-vs-git case divergence locally (in the pre-commit hook) where the
+ * hash-based drift check is blind on a case-insensitive filesystem.
+ */
+export const runCheckCase = (opts: ScopeOptions): void => {
+  const repoRoot = getRepoRoot();
+  const targets = packTargets(resolveTargetMods(repoRoot, discoverMods(repoRoot), opts));
+  const results = collectCaseMismatches(repoRoot, targets);
+
+  const problems = results.reduce((n, r) => n + r.mismatches.length, 0);
+  const problemText = problems > 0 ? err(`${problems} problem(s)`) : ok('0 problems');
+  console.log(`Case drift: checked ${targets.length} mod(s), ${problemText}.`);
+
+  for (const { mod, mismatches } of results) {
+    for (const mismatch of mismatches) {
+      console.error(`  ${glyph.bad} ${mod.relDir}: ${describeCaseMismatch(mismatch)}`);
+    }
+  }
+
+  if (problems > 0) process.exitCode = 1;
+};

--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -5,6 +5,7 @@ import { runGenerateConfigs } from './commands/generateConfigs';
 import { runPack } from './commands/pack';
 import { runBuildManifest } from './commands/buildManifest';
 import { runCheck } from './commands/check';
+import { runCheckCase } from './commands/checkCase';
 import { runNewMod } from './commands/newMod';
 import { err } from './lib/term';
 import type { ScopeOptions } from './lib/scope';
@@ -73,6 +74,10 @@ program
   .command('check')
   .description('CI drift check: configs + build locks vs. sources')
   .action(() => runCheck());
+
+withScope(program.command('check-case'))
+  .description('Fail if a working-tree file case differs from git')
+  .action((opts: ScopeOptions) => runCheckCase(opts));
 
 program.parseAsync(process.argv).catch((e) => {
   console.error(err(e instanceof Error ? e.message : String(e)));

--- a/scripts/src/lib/caseDrift.test.ts
+++ b/scripts/src/lib/caseDrift.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { findCaseMismatches, describeCaseMismatch } from './caseDrift';
+
+describe('findCaseMismatches', () => {
+  it('returns nothing when disk and tracked cases match exactly', () => {
+    const paths = ['mods/A/data/db/Race.xml', 'mods/A/data/db/npcclientappearance.xml'];
+    expect(findCaseMismatches(paths, paths)).toEqual([]);
+  });
+
+  it('detects a case-only difference in the file name', () => {
+    const tracked = ['mods/A/data/db/CommerceCommon.xml'];
+    const disk = ['mods/A/data/db/commercecommon.xml'];
+    expect(findCaseMismatches(tracked, disk)).toEqual([
+      { onDisk: 'mods/A/data/db/commercecommon.xml', tracked: 'mods/A/data/db/CommerceCommon.xml' },
+    ]);
+  });
+
+  it('detects a case-only difference in a directory segment', () => {
+    const tracked = ['mods/A/data/db/Race.xml'];
+    const disk = ['mods/A/data/DB/Race.xml'];
+    expect(findCaseMismatches(tracked, disk)).toEqual([
+      { onDisk: 'mods/A/data/DB/Race.xml', tracked: 'mods/A/data/db/Race.xml' },
+    ]);
+  });
+
+  it('ignores an untracked new file (no tracked counterpart)', () => {
+    const tracked = ['mods/A/data/db/Race.xml'];
+    const disk = ['mods/A/data/db/Race.xml', 'mods/A/data/db/BrandNew.xml'];
+    expect(findCaseMismatches(tracked, disk)).toEqual([]);
+  });
+
+  it('ignores a tracked file missing from disk (deletion in progress)', () => {
+    const tracked = ['mods/A/data/db/Race.xml', 'mods/A/data/db/Gone.xml'];
+    const disk = ['mods/A/data/db/Race.xml'];
+    expect(findCaseMismatches(tracked, disk)).toEqual([]);
+  });
+
+  it('reports multiple mismatches sorted by the on-disk path', () => {
+    const tracked = ['mods/A/data/db/Zed.xml', 'mods/A/data/db/Alpha.xml'];
+    const disk = ['mods/A/data/db/zed.xml', 'mods/A/data/db/alpha.xml'];
+    expect(findCaseMismatches(tracked, disk)).toEqual([
+      { onDisk: 'mods/A/data/db/alpha.xml', tracked: 'mods/A/data/db/Alpha.xml' },
+      { onDisk: 'mods/A/data/db/zed.xml', tracked: 'mods/A/data/db/Zed.xml' },
+    ]);
+  });
+});
+
+describe('describeCaseMismatch', () => {
+  it('names both the disk and tracked paths and the fix', () => {
+    const message = describeCaseMismatch({
+      onDisk: 'mods/A/data/db/commercecommon.xml',
+      tracked: 'mods/A/data/db/CommerceCommon.xml',
+    });
+    expect(message).toContain('working tree has "mods/A/data/db/commercecommon.xml"');
+    expect(message).toContain('git tracks "mods/A/data/db/CommerceCommon.xml"');
+    expect(message).toContain('generate-configs');
+  });
+});

--- a/scripts/src/lib/caseDrift.ts
+++ b/scripts/src/lib/caseDrift.ts
@@ -1,0 +1,40 @@
+export interface CaseMismatch {
+  /** The path as it exists in the working tree (wrong case). */
+  readonly onDisk: string;
+  /** The path as git tracks it (canonical case). */
+  readonly tracked: string;
+}
+
+/**
+ * Files whose working-tree name matches a tracked file case-insensitively but
+ * differs in case. On a case-insensitive filesystem (`core.ignorecase=true` on
+ * Windows) git silently keeps the old case after a case-only rename, so
+ * config.json's `usedFiles` + `sourceHash` (both scanned from disk) drift from
+ * the committed tree and only fail on a case-sensitive CI runner. Comparing the
+ * disk scan against `git ls-files` catches it locally instead.
+ *
+ * New files with no tracked counterpart, and tracked files missing from disk,
+ * produce no match — only a genuine case-only divergence is reported.
+ */
+export const findCaseMismatches = (
+  trackedPaths: readonly string[],
+  diskPaths: readonly string[],
+): CaseMismatch[] => {
+  const trackedByLower = new Map<string, string>();
+  for (const tracked of trackedPaths) trackedByLower.set(tracked.toLowerCase(), tracked);
+
+  const mismatches: CaseMismatch[] = [];
+  for (const onDisk of diskPaths) {
+    const tracked = trackedByLower.get(onDisk.toLowerCase());
+    if (tracked !== undefined && tracked !== onDisk) {
+      mismatches.push({ onDisk, tracked });
+    }
+  }
+
+  return mismatches.sort((a, b) => a.onDisk.localeCompare(b.onDisk));
+};
+
+/** One-line, actionable description of a single case mismatch. */
+export const describeCaseMismatch = ({ onDisk, tracked }: CaseMismatch): string =>
+  `filename case mismatch — working tree has "${onDisk}" but git tracks "${tracked}". ` +
+  `Rename the working-tree file to match git's case, then re-run generate-configs + pack.`;

--- a/scripts/src/lib/git.ts
+++ b/scripts/src/lib/git.ts
@@ -19,6 +19,20 @@ export interface ChangedOptions {
   base?: string;
 }
 
+/**
+ * Case-exact, repo-relative posix paths that git tracks (from the index).
+ * `git ls-files` reports the stored case regardless of `core.ignorecase`, so it
+ * is the source of truth for a file's canonical name — unlike a working-tree
+ * scan on a case-insensitive filesystem. Optionally scope to `pathspecs`.
+ */
+export const gitTrackedPaths = (repoRoot: string, pathspecs: string[] = []): string[] => {
+  const out = execFileSync('git', ['ls-files', '-z', '--', ...pathspecs], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return out.split('\0').filter(Boolean); // already posix, case-exact
+};
+
 /** Repo-relative paths (posix) that changed, per the requested git scope. */
 export const gitChangedPaths = (repoRoot: string, opts: ChangedOptions): string[] => {
   const args = ['diff', '--name-only'];


### PR DESCRIPTION
## Summary

Adds a **case-drift guard** to the maintainer tooling so a working-tree file whose name differs from git only by case can no longer silently drift `config.json` and blow up in CI.

### Background

On Windows (`core.ignorecase=true`) the filesystem is case-insensitive, so after a case-only rename of an already-tracked file, git keeps the old case in its index while the working tree shows the new case. `generate-configs`, `computeDataHash`, and the existing drift check all scan the **working tree**, so on Windows they happily read the diverged case and pass locally — then fail on the case-sensitive Linux CI runner (as seen in #174, where `usedFiles`/`sourceHash` referenced `CommerceCommon.xml` while the tree tracked `commercecommon.xml`).

`git ls-files` reports the **case-exact tracked name** regardless of `core.ignorecase`, so comparing the disk scan against it is a reliable signal that works locally too.

## What this adds

- `gitTrackedPaths` in [scripts/src/lib/git.ts](scripts/src/lib/git.ts) — case-exact tracked paths via `git ls-files -z`.
- [scripts/src/lib/caseDrift.ts](scripts/src/lib/caseDrift.ts) — pure `findCaseMismatches` (lowercase-keyed lookup; reports on-disk paths whose case differs from tracked, ignoring untracked-new and deleted files) + `describeCaseMismatch` for an actionable message. Fully unit-tested.
- [scripts/src/commands/checkCase.ts](scripts/src/commands/checkCase.ts) — `collectCaseMismatches` (one `git ls-files` call, scans each mod's `data/` + `images/`) and a scoped `runCheckCase`.
- Wired into [scripts/src/commands/check.ts](scripts/src/commands/check.ts) as a new `Case drift:` section, so `npm run check` (CI + manual) covers it.
- New `check-case` subcommand in [scripts/src/index.ts](scripts/src/index.ts) with the shared scope flags, plus a `check-case` script in `package.json`.
- [.husky/pre-commit](.husky/pre-commit) now runs `check-case --changed --staged`, so the divergence fails **at commit time on Windows** — where the hash-based drift check is blind — instead of only in CI.

## Where it earns its keep

- **Local (pre-commit, Windows):** the only check that catches the divergence before push.
- **CI (Linux):** effectively redundant (a fresh case-sensitive checkout always matches git), but kept in `check` so behavior is identical wherever it runs.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (new `caseDrift.test.ts`; full suite green)
- [x] Manual: injected a case-only rename on disk -> `check-case` fails naming the file; reverted -> `Case drift: checked N mod(s), 0 problems.`
- [x] `npm run check` prints both `Pack drift` and `Case drift` sections